### PR TITLE
Fixed incorrect macro syntax for HXML files

### DIFF
--- a/src/hxp/HXML.hx
+++ b/src/hxp/HXML.hx
@@ -308,7 +308,7 @@ abstract HXML(Array<String>) {
 	**/
 	public function addMacro (value:String):Void {
 		
-		this.push ("-macro " + value);
+		this.push ("--macro " + value);
 		
 	}
 	


### PR DESCRIPTION
Hello, just a tiny fix for incorrect macro syntax which would cause the hxml class to error out when trying to build with macros.