### PR TITLE
Optional codepath quotes

### DIFF
--- a/src/hxp/HXML.hx
+++ b/src/hxp/HXML.hx
@@ -362,9 +362,9 @@ abstract HXML(Array<String>)
 	/**
 		Adds a class path where `.hx` source files or packages (sub-directories) can be found.
 	**/
-	public function cp(path:String, quote:Bool = true):Void
+	public function cp(path:String):Void
 	{
-		if (quote)
+		if (path.indexOf(" ") != -1)
 		{
 			this.push("-cp \"" + path + "\"");
 		}

--- a/src/hxp/HXML.hx
+++ b/src/hxp/HXML.hx
@@ -362,9 +362,16 @@ abstract HXML(Array<String>)
 	/**
 		Adds a class path where `.hx` source files or packages (sub-directories) can be found.
 	**/
-	public function cp(path:String):Void
+	public function cp(path:String, quote:Bool = true):Void
 	{
-		this.push("-cp \"" + path + "\"");
+		if (quote)
+		{
+			this.push("-cp \"" + path + "\"");
+		}
+		else
+		{
+			this.push("-cp " + path);
+		}
 	}
 
 	/**
@@ -1191,6 +1198,7 @@ typedef HXMLConfig =
 		Adds a class path where `.hx` source files or packages (sub-directories) can be found.
 	**/
 	@:optional var cp:Array<String>;
+
 	/**
 		Set current working directory.
 	**/


### PR DESCRIPTION
Hello,
This small change allows you to opt out of code paths being surrounded by quotes. My reason for wanting this is to work around a bug in lix where it fails to read code paths surrounded by quotes (https://github.com/lix-pm/haxeshim/issues/32).
I've been using my own hxp fork for around 6 months now where the only change is removing code path quoting, but I thought I'd finally get around to making a PR for it to be opt out so I don't have to keep my own fork up to date.

Cheers.