### PR TITLE
Fix 'haxelib path lib' for lix-pm installs

### DIFF
--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -128,7 +128,7 @@ class Haxelib
 				var cacheDryRun = System.dryRun;
 				System.dryRun = false;
 
-				output = Haxelib.runProcess(workingDirectory, ["path", name], true, true, true);
+				output = Haxelib.runProcess(workingDirectory, ["path", name], true, true, true, false, false, true);
 				if (output == null) output = "";
 
 				System.dryRun = cacheDryRun;
@@ -432,7 +432,7 @@ class Haxelib
 	}
 
 	public static function runProcess(path:String, args:Array<String>, waitForOutput:Bool = true, safeExecute:Bool = true, ignoreErrors:Bool = false,
-			print:Bool = false, returnErrorValue:Bool = false):String
+			print:Bool = false, returnErrorValue:Bool = false, allowNonExecutables:Bool = false):String
 	{
 		if (pathOverrides.exists("haxelib"))
 		{
@@ -443,7 +443,7 @@ class Haxelib
 				Log.error("Cannot find haxelib script: " + script);
 			}
 
-			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue);
+			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, allowNonExecutables);
 		}
 		else
 		{
@@ -456,7 +456,7 @@ class Haxelib
 
 			// }
 
-			return System.runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue);
+			return System.runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, allowNonExecutables);
 		}
 	}
 

--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -1168,7 +1168,7 @@ class System
 
 		if (!dryRun)
 		{
-			var process = allowNonExecutables ? new Process('$command ${args.join(" ")}', null) : new Process(command, args);
+			var process = allowNonExecutables ? new Process(command + " " + args.join(" ")) : new Process(command, args);
 			var buffer = new BytesOutput();
 
 			if (waitForOutput)

--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -1076,7 +1076,7 @@ class System
 	}
 
 	public static function runProcess(path:String, command:String, args:Array<String>, waitForOutput:Bool = true, safeExecute:Bool = true,
-			ignoreErrors:Bool = false, print:Bool = false, returnErrorValue:Bool = false):String
+			ignoreErrors:Bool = false, print:Bool = false, returnErrorValue:Bool = false, allowNonExecutables = false):String
 	{
 		if (print)
 		{
@@ -1113,7 +1113,7 @@ class System
 					Log.error("The specified target path \"" + path + "\" does not exist");
 				}
 
-				return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue);
+				return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue, allowNonExecutables);
 			}
 			catch (e:Dynamic)
 			{
@@ -1127,12 +1127,12 @@ class System
 		}
 		else
 		{
-			return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue);
+			return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue, allowNonExecutables);
 		}
 	}
 
 	private static function _runProcess(path:String, command:String, args:Array<String>, waitForOutput:Bool, safeExecute:Bool, ignoreErrors:Bool,
-			returnErrorValue:Bool):String
+			returnErrorValue:Bool, allowNonExecutables:Bool):String
 	{
 		var oldPath:String = "";
 
@@ -1168,7 +1168,7 @@ class System
 
 		if (!dryRun)
 		{
-			var process = new Process(command, args);
+			var process = allowNonExecutables ? new Process('$command ${args.join(" ")}', null) : new Process(command, args);
 			var buffer = new BytesOutput();
 
 			if (waitForOutput)


### PR DESCRIPTION
This PR makes possible to run 'lix run lime', which internally seems to rely on the command 'haxelib path lime'. 

The changes should not affect existing scripts:
- `hxp.System.runProcess` has an additional argument `allowNonExecutables`. If true, the latter changes the way `sys.io.Process` is instantiated by using `null` instead of `args`. This allows running shell commands that are not executables, as well as executables.

An alternative to the above approach would be to do as `hxp.System.runCommand` does, that would be something like:
```haxe
// automatically allow non-executables commands when `args` is an empty array
args.length != 0 ? new Process(command, args) : new Process(command);
```
This would not require a new argument, but some users might experience different behaviors; For instance on Windows `System.runProcess("dir", [])` will behave differently.