### PR TITLE
Support for scoped setups

### DIFF
--- a/scripts/AliasScript.hx
+++ b/scripts/AliasScript.hx
@@ -7,6 +7,6 @@ class AliasScript
 	public static function main()
 	{
 		var args = ["run", Compiler.getDefine("command")].concat(Sys.args());
-		Sys.exit(Sys.command("haxelib", args));
+		Sys.exit(Sys.command("haxelib " + args.join(" ")));
 	}
 }

--- a/src/hxp/HXML.hx
+++ b/src/hxp/HXML.hx
@@ -409,15 +409,18 @@ abstract HXML(Array<String>)
 				if (lines[i].indexOf("-cp ") == 0)
 				{
 					var quote:Int = lines[i].indexOf('"');
+					var cp:String;
 
 					if (quote > 0)
 					{
-						lines[i] = "-cp \"" + hxmlDirectory + "/" + lines[i].substr(quote + 1);
+						cp = lines[i].substring(quote + 1, lines[i].lastIndexOf("\""));
 					}
 					else
 					{
-						lines[i] = "-cp " + hxmlDirectory + "/" + lines[i].substr(4);
+						cp = lines[i].substr("-cp ".length);
 					}
+
+					lines[i] = "-cp \"" + Path.normalize(hxmlDirectory + "/" + cp) + "\"";
 				}
 			}
 

--- a/src/hxp/HXML.hx
+++ b/src/hxp/HXML.hx
@@ -395,6 +395,11 @@ abstract HXML(Array<String>)
 		var hxml:HXML = fromFile(path);
 		var hxmlDirectory = Path.directory(path);
 
+		if (hxml == null)
+		{
+			Log.error("The specified target path \"" + path + "\" does not exist");
+		}
+
 		if (fromDirectory != "" && fromDirectory != hxmlDirectory)
 		{
 			var lines:Array<String> = cast hxml;

--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -403,8 +403,11 @@ class Haxelib
 		return versions.get(haxelib.name);
 	}
 
-	public static function runCommand(path:String, args:Array<String>, safeExecute:Bool = true, ignoreErrors:Bool = false, print:Bool = false):Int
+	public static function runCommand(path:String, args:Array<String>, safeExecute:Bool = true, ignoreErrors:Bool = false, print:Bool = false,
+			allowNonExecutables:Bool = false):Int
 	{
+		var command:String;
+
 		if (pathOverrides.exists("haxelib"))
 		{
 			var script = Path.combine(pathOverrides.get("haxelib"), "run.n");
@@ -414,21 +417,21 @@ class Haxelib
 				Log.error("Cannot find haxelib script: " + script);
 			}
 
-			return System.runCommand(path, "neko", [script].concat(args), safeExecute, ignoreErrors, print);
+			command = "neko";
+			args = [script].concat(args);
 		}
 		else
 		{
-			// var haxe = Sys.getEnv ("HAXEPATH");
-			var command = "haxelib";
-
-			// if (haxe != null) {
-
-			// 	command = Path.combine (haxe, command);
-
-			// }
-
-			return System.runCommand(path, command, args, safeExecute, ignoreErrors, print);
+			command = "haxelib";
 		}
+
+		if (allowNonExecutables)
+		{
+			command += " " + args.join(" ");
+			args = null;
+		}
+
+		return System.runCommand(path, command, args, safeExecute, ignoreErrors, print);
 	}
 
 	public static function runProcess(path:String, args:Array<String>, waitForOutput:Bool = true, safeExecute:Bool = true, ignoreErrors:Bool = false,

--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -446,7 +446,8 @@ class Haxelib
 				Log.error("Cannot find haxelib script: " + script);
 			}
 
-			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, allowNonExecutables);
+			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue,
+				allowNonExecutables);
 		}
 		else
 		{

--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -416,20 +416,21 @@ class Haxelib
 				Log.error("Cannot find haxelib script: " + script);
 			}
 
-			command = "neko";
-			args = ['"$script"'].concat(args);
+			command = 'neko "$script"';
 		}
 		else
 		{
 			command = "haxelib";
 		}
 
-		return System.runCommand(path, command + " " + args.join(" "), null, safeExecute, ignoreErrors, print);
+		return System.runCommand(path, command + " " + args.join(" "), safeExecute, ignoreErrors, print);
 	}
 
 	public static function runProcess(path:String, args:Array<String>, waitForOutput:Bool = true, safeExecute:Bool = true, ignoreErrors:Bool = false,
 			print:Bool = false, returnErrorValue:Bool = false):String
 	{
+		var command:String;
+
 		if (pathOverrides.exists("haxelib"))
 		{
 			var script = Path.combine(pathOverrides.get("haxelib"), "run.n");
@@ -439,21 +440,14 @@ class Haxelib
 				Log.error("Cannot find haxelib script: " + script);
 			}
 
-			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, true);
+			command = 'neko "$script"';
 		}
 		else
 		{
-			// var haxe = Sys.getEnv ("HAXEPATH");
-			var command = "haxelib";
-
-			// if (haxe != null) {
-
-			// 	command = Path.combine (haxe, command);
-
-			// }
-
-			return System.runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, true);
+			command = "haxelib";
 		}
+
+		return System.runProcess(path, command + " " + args.join(" "), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue);
 	}
 
 	public static function setOverridePath(haxelib:Haxelib, path:String):Void

--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -128,7 +128,7 @@ class Haxelib
 				var cacheDryRun = System.dryRun;
 				System.dryRun = false;
 
-				output = Haxelib.runProcess(workingDirectory, ["path", name], true, true, true, false, false, true);
+				output = Haxelib.runProcess(workingDirectory, ["path", name], true, true, true);
 				if (output == null) output = "";
 
 				System.dryRun = cacheDryRun;

--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -403,8 +403,7 @@ class Haxelib
 		return versions.get(haxelib.name);
 	}
 
-	public static function runCommand(path:String, args:Array<String>, safeExecute:Bool = true, ignoreErrors:Bool = false, print:Bool = false,
-			allowNonExecutables:Bool = false):Int
+	public static function runCommand(path:String, args:Array<String>, safeExecute:Bool = true, ignoreErrors:Bool = false, print:Bool = false):Int
 	{
 		var command:String;
 
@@ -418,24 +417,18 @@ class Haxelib
 			}
 
 			command = "neko";
-			args = [script].concat(args);
+			args = ['"$script"'].concat(args);
 		}
 		else
 		{
 			command = "haxelib";
 		}
 
-		if (allowNonExecutables)
-		{
-			command += " " + args.join(" ");
-			args = null;
-		}
-
-		return System.runCommand(path, command, args, safeExecute, ignoreErrors, print);
+		return System.runCommand(path, command + " " + args.join(" "), null, safeExecute, ignoreErrors, print);
 	}
 
 	public static function runProcess(path:String, args:Array<String>, waitForOutput:Bool = true, safeExecute:Bool = true, ignoreErrors:Bool = false,
-			print:Bool = false, returnErrorValue:Bool = false, allowNonExecutables:Bool = false):String
+			print:Bool = false, returnErrorValue:Bool = false):String
 	{
 		if (pathOverrides.exists("haxelib"))
 		{
@@ -446,8 +439,7 @@ class Haxelib
 				Log.error("Cannot find haxelib script: " + script);
 			}
 
-			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue,
-				allowNonExecutables);
+			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, true);
 		}
 		else
 		{
@@ -460,7 +452,7 @@ class Haxelib
 
 			// }
 
-			return System.runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, allowNonExecutables);
+			return System.runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, true);
 		}
 	}
 

--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -128,7 +128,7 @@ class Haxelib
 				var cacheDryRun = System.dryRun;
 				System.dryRun = false;
 
-				output = Haxelib.runProcess(workingDirectory, ["path", name], true, true, true);
+				output = Haxelib.runProcess(workingDirectory, ["path", name], true, true, true, false, false, true);
 				if (output == null) output = "";
 
 				System.dryRun = cacheDryRun;
@@ -432,7 +432,7 @@ class Haxelib
 	}
 
 	public static function runProcess(path:String, args:Array<String>, waitForOutput:Bool = true, safeExecute:Bool = true, ignoreErrors:Bool = false,
-			print:Bool = false, returnErrorValue:Bool = false):String
+			print:Bool = false, returnErrorValue:Bool = false, allowNonExecutables:Bool = false):String
 	{
 		if (pathOverrides.exists("haxelib"))
 		{
@@ -443,7 +443,7 @@ class Haxelib
 				Log.error("Cannot find haxelib script: " + script);
 			}
 
-			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue);
+			return System.runProcess(path, "neko", [script].concat(args), waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, allowNonExecutables);
 		}
 		else
 		{
@@ -456,7 +456,7 @@ class Haxelib
 
 			// }
 
-			return System.runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue);
+			return System.runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, print, returnErrorValue, allowNonExecutables);
 		}
 	}
 

--- a/src/hxp/PlatformTools.hx
+++ b/src/hxp/PlatformTools.hx
@@ -50,7 +50,7 @@ class PlatformTools
 	{
 		Log.info("", " - \x1b[1mStarting local web server:\x1b[0m http://localhost:" + port);
 
-		var args = ["run", "http-server", path, "-p", Std.string(port), "-c-1", "--cors"];
+		var args = ["run", "http-server", '"$path"', "-p", Std.string(port), "-c-1", "--cors"];
 
 		if (!openBrowser && !Log.verbose)
 		{

--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -1076,7 +1076,7 @@ class System
 	}
 
 	public static function runProcess(path:String, command:String, args:Array<String>, waitForOutput:Bool = true, safeExecute:Bool = true,
-			ignoreErrors:Bool = false, print:Bool = false, returnErrorValue:Bool = false, allowNonExecutables = false):String
+			ignoreErrors:Bool = false, print:Bool = false, returnErrorValue:Bool = false):String
 	{
 		if (print)
 		{
@@ -1113,7 +1113,7 @@ class System
 					Log.error("The specified target path \"" + path + "\" does not exist");
 				}
 
-				return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue, allowNonExecutables);
+				return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue);
 			}
 			catch (e:Dynamic)
 			{
@@ -1127,12 +1127,12 @@ class System
 		}
 		else
 		{
-			return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue, allowNonExecutables);
+			return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue);
 		}
 	}
 
 	private static function _runProcess(path:String, command:String, args:Array<String>, waitForOutput:Bool, safeExecute:Bool, ignoreErrors:Bool,
-			returnErrorValue:Bool, allowNonExecutables:Bool):String
+			returnErrorValue:Bool):String
 	{
 		var oldPath:String = "";
 
@@ -1168,7 +1168,7 @@ class System
 
 		if (!dryRun)
 		{
-			var process = allowNonExecutables ? new Process(command + " " + args.join(" ")) : new Process(command, args);
+			var process = new Process(command, args);
 			var buffer = new BytesOutput();
 
 			if (waitForOutput)

--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -1284,7 +1284,7 @@ class System
 
 		// 	try {
 
-		// 		var process = new Process ("haxe", [ "-version" ]);
+		// 		var process = new Process ("haxe -version");
 		// 		_haxeVersion = StringTools.trim (process.stderr.readAll ().toString ());
 
 		// 		if (_haxeVersion == "") {

--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -1168,7 +1168,7 @@ class System
 
 		if (!dryRun)
 		{
-			var process = allowNonExecutables ? new Process('$command ${args.join(" ")}', null) : new Process(command, args);
+			var process = allowNonExecutables ? new Process(command + " " + args.join(" ")) : new Process(command, args);
 			var buffer = new BytesOutput();
 
 			if (waitForOutput)

--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -1076,7 +1076,7 @@ class System
 	}
 
 	public static function runProcess(path:String, command:String, args:Array<String>, waitForOutput:Bool = true, safeExecute:Bool = true,
-			ignoreErrors:Bool = false, print:Bool = false, returnErrorValue:Bool = false):String
+			ignoreErrors:Bool = false, print:Bool = false, returnErrorValue:Bool = false, allowNonExecutables = false):String
 	{
 		if (print)
 		{
@@ -1113,7 +1113,7 @@ class System
 					Log.error("The specified target path \"" + path + "\" does not exist");
 				}
 
-				return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue);
+				return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue, allowNonExecutables);
 			}
 			catch (e:Dynamic)
 			{
@@ -1127,12 +1127,12 @@ class System
 		}
 		else
 		{
-			return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue);
+			return _runProcess(path, command, args, waitForOutput, safeExecute, ignoreErrors, returnErrorValue, allowNonExecutables);
 		}
 	}
 
 	private static function _runProcess(path:String, command:String, args:Array<String>, waitForOutput:Bool, safeExecute:Bool, ignoreErrors:Bool,
-			returnErrorValue:Bool):String
+			returnErrorValue:Bool, allowNonExecutables:Bool):String
 	{
 		var oldPath:String = "";
 
@@ -1168,7 +1168,7 @@ class System
 
 		if (!dryRun)
 		{
-			var process = new Process(command, args);
+			var process = allowNonExecutables ? new Process('$command ${args.join(" ")}', null) : new Process(command, args);
 			var buffer = new BytesOutput();
 
 			if (waitForOutput)


### PR DESCRIPTION
Allow using hxp from local scopes:

- This PR depends on #21, and changes `Haxelib.runCommand` and `Haxelib.runProcess` to always pre-concatenate the arguments. It allows haxelib to be run from a non-executable command (for instance with lix). The concatenation is pretty naive, so care needs to be taken when dealing with paths.
- `HXML.buildFile` is added and gives the possibility to build a `hxml` file from a given directory. To work this required to remove the comments from `hxml` files - see changes in `fromString`.
- A few calls have been updated to allow non-executables commands (namely neko, haxelib and haxe).
