### PR TITLE
Fix minor null pointer exception

### DIFF
--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -1069,7 +1069,7 @@ class System
 
 		if (result != 0)
 		{
-			throw("Error running: " + command + " " + args.join(" ") + " [" + path + "]");
+			throw("Error running: " + command + (args != null ? " " + args.join(" ") : "") + " [" + path + "]");
 		}
 
 		return result;


### PR DESCRIPTION
`hxp.System.runCommand` can receive null for the arg `args`, but wasn't checking that in case of error.