### PR TITLE
Allow deletion of stale templates.

### DIFF
--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -22,6 +22,7 @@ class System
 	private static var _hostPlatform:HostPlatform;
 	private static var _isText:Map<String, Bool>;
 	private static var _processorCores:Int = 0;
+	private static var _templates:Array<String> = [];
 
 	private static function __init__():Void
 	{
@@ -201,6 +202,8 @@ class System
 
 		if (process && context != null)
 		{
+			_templates.push(destination);
+
 			if (_isText.exists(extension) && !_isText.get(extension))
 			{
 				copyIfNewer(source, destination);
@@ -360,6 +363,24 @@ class System
 			}
 		}
 		catch (e:Dynamic) {}
+	}
+
+	public static function deleteStaleTemplates(targetDirectory:String)
+	{
+		var templatesFile = Path.combine(targetDirectory, ".templates");
+		if (FileSystem.exists(templatesFile))
+		{
+			for (template in File.getContent(templatesFile).split("\n"))
+			{
+				if (_templates.indexOf(template) < 0)
+				{
+					deleteFile(template);
+				}
+			}
+		}
+
+		File.saveContent(templatesFile, _templates.join("\n"));
+		_templates.resize(0);
 	}
 
 	private static function findTemplateRecursive_(templatePaths:Array<String>, source:String, templateFiles:Array<String>, templateMatched:Map<String, Bool>,


### PR DESCRIPTION
Template files have a habit of sticking around in the output folder, even if the project no longer needs or wants them. But if we save a list of templates after a build, we can compare against that list in future builds to locate no-longer-used files.

The intent is for `deleteStaleTemplates()` to run every time. It doesn't just delete the files, it saves the list for next time. A drawback of this implementation is that if it gets skipped, the list doesn't get updated, and if the list isn't updated, the next run might not find all the stale templates. This can of course be fixed with a clean build.

Like #27, this is one half of a potential solution to openfl/lime#1546. (The other half is openfl/lime#1550.) And I'd argue it's a better solution, requiring less maintenance and having no 31-character-long function names.