### PR TITLE
Expose cpuInfo as public static var so it can be used in lime to detect a RaspberryPi 

### DIFF
--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -16,10 +16,12 @@ class System
 	public static var dryRun:Bool = false;
 	public static var hostArchitecture(get, never):HostArchitecture;
 	public static var hostPlatform(get, never):HostPlatform;
+	public static var cpuInfo(get, never):String;
 	public static var processorCores(get, never):Int;
 	private static var _haxeVersion:String;
 	private static var _hostArchitecture:HostArchitecture;
 	private static var _hostPlatform:HostPlatform;
+	private static var _cpuInfo:String;
 	private static var _isText:Map<String, Bool>;
 	private static var _processorCores:Int = 0;
 
@@ -1501,6 +1503,8 @@ class System
 			else if (new EReg("linux", "i").match(Sys.systemName()))
 			{
 				_hostPlatform = LINUX;
+				_cpuInfo = runProcess("", "cat", ["/proc/cpuinfo"], true, true, true);
+				if (_cpuInfo == null) _cpuInfo = "";
 			}
 			else if (new EReg("mac", "i").match(Sys.systemName()))
 			{
@@ -1511,6 +1515,11 @@ class System
 		}
 
 		return _hostPlatform;
+	}
+
+	private static function get_cpuInfo():String
+	{
+		return _cpuInfo;
 	}
 
 	private static function get_processorCores():Int
@@ -1537,12 +1546,16 @@ class System
 
 				if (result == null)
 				{
-					var cpuinfo = runProcess("", "cat", ["/proc/cpuinfo"], true, true, true);
+					_cpuInfo = runProcess("", "cat", ["/proc/cpuinfo"], true, true, true);
 
-					if (cpuinfo != null)
+					if (_cpuInfo != null)
 					{
-						var split = cpuinfo.split("processor");
+						var split = _cpuInfo.split("processor");
 						result = Std.string(split.length - 1);
+					}
+					else
+					{
+						_cpuInfo = "";
 					}
 				}
 			}


### PR DESCRIPTION
If cpuInfo is stored as a public static var it can be used by Lime to detect if a linux platform is a RaspberryPi.
rather than assuming ARMV7 is a pi.
cpuinfo is used as a local var at the moment only in get_processorCores (which is not always called by lime)
By populating cpuInfo in get_hostPlatform we can make sure it has a value when Lime is trying to detect if it's a Raspberry Pi.

This will help in solving an Error that is thrown when you build an html5 project on Pi and neko runs svg.n to process the application Icon. Neko fails to see that it is a raspberry pi because it only checks for a -rpi flag and tries to load the regular linux-ndll. 
