### PR TITLE
fix for quirk when running 32bit os with 64bit kernel on raspberryPi

### DIFF
--- a/src/hxp/System.hx
+++ b/src/hxp/System.hx
@@ -1468,7 +1468,19 @@ class System
 					}
 					else if (output.indexOf("arm64") > -1 || output.indexOf("aarch64") > -1)
 					{
-						_hostArchitecture = ARM64;
+						var getconfProcess = new Process("getconf", ["LONG_BIT"]);
+						var getconfOutput = getconfProcess.stdout.readAll().toString();
+						var getconfError = getconfProcess.stderr.readAll().toString();
+						getconfProcess.exitCode();
+						getconfProcess.close();
+						if (StringTools.trim(getconfOutput) == "64")
+						{
+							_hostArchitecture = ARM64;
+						}
+						else
+						{
+							_hostArchitecture = ARMV7;
+						}
 					}
 					else if (output.indexOf("64") > -1)
 					{


### PR DESCRIPTION
A while ago, updates to raspberryPi OS install a 64bit kernel on a 32bit OS.  That means it always reports back as being a aarch64 Architecture even though the rest of the os is 32bit. This fix uses the `getconf` command to determine if the os is 32 or 64 bit.