### PR TITLE
Recognize \r\n line breaks.

### DIFF
--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -137,7 +137,7 @@ class Haxelib
 
 			Log.verbose = cache;
 
-			var lines = output.split("\n");
+			var lines = ~/\r?\n/g.split(output);
 			var result = "";
 
 			for (i in 1...lines.length)


### PR DESCRIPTION
Leaving a trailing \r (on systems where that happens) makes it unable to find the folder.

An alternate solution would be to do `StringTools.trim()` for each line.