### PR TITLE
Add support for Windows-style paths in `Path.isAbsolute()`.

### DIFF
--- a/src/hxp/Path.hx
+++ b/src/hxp/Path.hx
@@ -110,6 +110,11 @@ class Path extends HaxePath
 
 	public static function isAbsolute(path:String):Bool
 	{
+		if (System.hostPlatform == WINDOWS && path.indexOf(":") == 1)
+		{
+			return true;
+		}
+		
 		if (StringTools.startsWith(path, "/") || StringTools.startsWith(path, "\\"))
 		{
 			return true;


### PR DESCRIPTION
Now, on WIndows machines, it will check both styles, while on anything else it will only check Unix-style paths as before. It's hard to imagine Windows needing to check Unix-style paths, but not impossible, so I erred on the side of caution.