### PR TITLE
Comments and empty lines are ignored when parsing string

### DIFF
--- a/src/hxp/HXML.hx
+++ b/src/hxp/HXML.hx
@@ -410,7 +410,9 @@ abstract HXML(Array<String>)
 
 			for (line in lines)
 			{
-				value.push(StringTools.trim(line));
+				var str = StringTools.trim(line);
+				if (str.length == 0 || StringTools.startsWith(str, "#")) continue;
+				value.push(str);
 			}
 		}
 


### PR DESCRIPTION
Just makes it so that comments and empty lines are ignored when parsing a string or an .hxml file, simple.
There isn't much to it really ¯\\_(ツ)_/¯