### PR TITLE
Add getPathClassPath to Haxelib.hx

### DIFF
--- a/src/hxp/Haxelib.hx
+++ b/src/hxp/Haxelib.hx
@@ -343,6 +343,24 @@ class Haxelib
 		}
 		return paths.get(name);
 	}
+	
+	public static function getPathClassPath(path:String):String
+	{
+		path = Path.combine(path, "haxelib.json");
+
+		if (FileSystem.exists(path))
+		{
+			try
+			{
+				var json = Json.parse(File.getContent(path));
+				var classPathString:String = json.classPath;
+				return classPathString;
+			}
+			catch (e:Dynamic) {}
+		}
+
+		return null;
+	}
 
 	public static function getPathVersion(path:String):Version
 	{


### PR DESCRIPTION
This new function in Haxelib.hx returns the classPath property from a library's haxelib.json file using a provided path. If the file cannot be found or the classPath property isn't present, the function will return null.